### PR TITLE
Add missing janitor import

### DIFF
--- a/processing/src/processing_lasan.R
+++ b/processing/src/processing_lasan.R
@@ -5,7 +5,7 @@
 # =========================================
 # OneDrive-HumanRightsWatch/HRW/HRW-us-losangeles-policinghomelessness/processing/src/processing_lasan.r
 library(pacman)
-p_load(lubridate, readxl, readr, rcartocolor, extrafont, scales, tidycensus,
+p_load(lubridate, readxl, readr, rcartocolor, extrafont, scales, tidycensus, janitor,
        CGPfunctions, tidyverse, qs, fuzzyjoin)
 options(scipen=999)
 


### PR DESCRIPTION
Without importing janitor, an error is produced saying that the clean_names() function cannot be found.